### PR TITLE
Workaround for OpenDDS 3.20.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 /build
 /.venv
 /dist
+/_pyopendds

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ for the current status of the limitations.
 - CPython >= 3.7
   - This uses the C API of CPython, so other Python implementations like PyPy
     are not offically supported.
+  - If building Python from source, make sure to run the configure script with
+    `--enable-shared`. PyOpenDDS doesn't currently support building with the
+    statically-linkable Python library.
 - OpenDDS >= 3.16
 - CMake >= 3.12
-- A C++14 Compiler
+- A compiler that supports C++14 or later.
 
 ## Building PyOpenDDS and Running the Basic Test
 
@@ -38,7 +41,8 @@ cmake ..
 make
 
 # Build and Install Basic Test Python Type Support
-itl2py -o basic_output basic_idl basic.itl
+itl2py -o basic_output basic_idl opendds_generated/basic.itl
+# If using OpenDDS 3.19 or before, then just specify basic.itl
 cd basic_output
 pip install .
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -18,7 +18,8 @@ below in this directory.
     make
 
     # Build and Install Basic Test Python Type Support
-    itl2py -o basic_output basic_idl basic.itl
+    itl2py -o basic_output basic_idl opendds_generated/basic.itl
+    # If using OpenDDS 3.19 or before, then just specify basic.itl
     cd basic_output
     pip install .
 

--- a/pyopendds/dev/itl2py/__main__.py
+++ b/pyopendds/dev/itl2py/__main__.py
@@ -64,9 +64,12 @@ the exepcted config file is not there, then this option becomes required.'''),
     config_filename = '{}Config.cmake'.format(args.idl_library_cmake_name)
     config_path = args.idl_library_build_dir / config_filename
     if not config_path.is_file():
+        args.idl_library_build_dir = Path('.').resolve()
+        config_path = args.idl_library_build_dir / config_filename
+    if not config_path.is_file():
         sys.exit('''\
-Native IDL library CMake config file {} does not exist, please pass the
-directory for it (where cmake was ran) using --idl-library-build-dir'''.format(config_path))
+Could not find native IDL library CMake config file {}, please pass the
+directory for it (where cmake was ran) using --idl-library-build-dir'''.format(config_filename))
     # CMake will freak out if there are DOS-style slashes in the path
     args.idl_library_build_dir = args.idl_library_build_dir.as_posix()
 

--- a/pyopendds/dev/util.py
+++ b/pyopendds/dev/util.py
@@ -100,3 +100,13 @@ def build_cmake_project(source_dir, build_dir, cfg_args=[], build_args=[]):
         *cfg_args
     )
     run_cmake('--build', str(build_dir), '--config', build_type, *build_args)
+
+
+def find_itl_file(build_dir, itl_filename):
+    path = build_dir / itl_filename
+    if not path.is_file():
+        path = build_dir / 'opendds_generated' / itl_filename
+    if not path.is_file():
+        raise FileNotFoundError("Couldn't find {} in {}".format(
+            repr(itl_filename), repr(str(build_dir))))
+    return path

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os
 import inspect
 from pathlib import Path
 from setuptools import setup, find_packages
+import shutil
 
 import cmake_build_extension
 
@@ -28,6 +29,8 @@ setup(
                 '-DCALL_FROM_SETUP_PY:BOOL=ON',
                 '-DPYOPENDDS_INCLUDE='
                     + str(Path(__file__).resolve().parent / 'pyopendds/dev/include'),
+                # https://github.com/diegoferigo/cmake-build-extension/issues/26
+                f"-DCMAKE_MAKE_PROGRAM={shutil.which('ninja')}",
             ],
             cmake_build_type=build_type,
         )

--- a/tests/basic_test/run_test.py
+++ b/tests/basic_test/run_test.py
@@ -8,6 +8,7 @@ from pyopendds.dev.util import (
     run_python,
     wait_or_kill,
     build_cmake_project,
+    find_itl_file,
 )
 
 
@@ -27,7 +28,8 @@ def run_test(args):
 
         # Generate and Install Python Package
         pack_dir = 'basic_output'
-        run_command('itl2py', '-o', pack_dir, 'basic_idl', 'basic.itl',
+        run_command('itl2py', '-o', pack_dir, 'basic_idl',
+            find_itl_file(build_dir, 'basic.itl'),
             cwd=build_dir, exit_on_error=True)
         run_python('-m', 'pip', '--verbose', 'install', '.',
             cwd=(build_dir / pack_dir), exit_on_error=True)


### PR DESCRIPTION
https://github.com/objectcomputing/OpenDDS/pull/3315 changed where generated files are placed. Will need probably need long term solution.

Also:
- Workaround https://github.com/diegoferigo/cmake-build-extension/pull/29
- Clarify apparent issue in https://github.com/oci-labs/pyopendds/issues/39